### PR TITLE
Historical Prices fetching and Markovitz optimal allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.pyd
 env/
 venv/
+.venv/
 *.egg-info/
 .ipynb_checkpoints/
 

--- a/Notebooks/NotebooksLoader/exampleMarkovitz.py
+++ b/Notebooks/NotebooksLoader/exampleMarkovitz.py
@@ -1,0 +1,32 @@
+from Models.Allocation import OptimalAllocation
+
+w = OptimalAllocation(["AAPL","MSFT","GOOG","AMZN"], method="Markovitz", allow_short=False)
+print("Optimal portfolio weights:")
+for ticker, weight in zip(["AAPL", "MSFT", "GOOG", "AMZN"], w):
+    print(f"  {ticker}: {weight*100:.4f}"+"%")
+print(f"Total weight allocated: {w.sum():.4f}")
+
+w_french = OptimalAllocation(
+    ["ENGI.PA", "TTE.PA", "SAN.PA", "ACA.PA"],
+    method="Markovitz",
+    allow_short=False
+)
+
+print("Optimal portfolio weights:")
+for ticker, weight in zip(["ENGI.PA", "TTE.PA", "SAN.PA", "ACA.PA"], w_french):
+    print(f"  {ticker}: {weight*100:.4f}"+"%")
+print(f"Total weight allocated: {w_french.sum():.4f}")
+
+
+w_french_withReturn = OptimalAllocation(
+    ["ENGI.PA", "TTE.PA", "SAN.PA", "ACA.PA"],
+    method="Markovitz",
+    allow_short=False,
+    target_return=0.10  # 10% annualized target return
+)
+
+print("Optimal portfolio weight with target annual return of 10%:")
+for ticker, weight in zip(["ENGI.PA", "TTE.PA", "SAN.PA", "ACA.PA"],w_french_withReturn):
+    print(f"  {ticker}: {weight*100:.4f}"+"%")
+print(f"Total weight allocated: {w_french_withReturn.sum():.4f}")
+

--- a/Notebooks/NotebooksLoader/test_import_data.ipynb
+++ b/Notebooks/NotebooksLoader/test_import_data.ipynb
@@ -17,27 +17,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "c1324701",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5439.224999999999"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "0.95*5725.5\n"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "id": "f9e13511",
    "metadata": {},

--- a/src/MarketDataLoader/HistoricalPricesLoader.py
+++ b/src/MarketDataLoader/HistoricalPricesLoader.py
@@ -1,0 +1,59 @@
+"""
+PriceLoader.py
+- Downloads historical High/Low/Close from Yahoo Finance (2 years daily by default).
+- Returns a dict of DataFrames keyed by measure: 'Close','High','Low'.
+"""
+
+from typing import List, Dict
+import pandas as pd
+import datetime
+import yfinance as yf
+
+
+def load_prices(tickers: List[str], period_days: int = 730) -> Dict[str, pd.DataFrame]:
+    """
+    Download daily historical prices for given tickers from Yahoo Finance.
+
+    Parameters
+    ----------
+    tickers : list[str]
+        List of tickers (e.g. ["AAPL", "MSFT"]).
+    period_days : int
+        Number of days to look back (default 730 ≈ 2 years).
+
+    Returns
+    -------
+    dict
+        { 'Close': DataFrame, 'High': DataFrame, 'Low': DataFrame }
+        Each DataFrame has index = date, columns = tickers.
+    """
+    end = datetime.date.today()
+    start = end - datetime.timedelta(days=period_days)
+    # yfinance download: multi-ticker => columns are multiindex (field, ticker)
+    df = yf.download(tickers, start=start.isoformat(), end=end.isoformat(), progress=False, group_by='ticker', threads=True)
+
+    # If single ticker, yfinance returns normal columns; normalize to multiindex
+    # We'll create per-measure DataFrames
+    measures = ['Close', 'High', 'Low']
+    out = {}
+    # Try two possible df layouts: (1) top-level columns are fields when single ticker, or
+    # (2) MultiIndex where first level field, second level ticker or vice versa.
+    # Simpler robust approach: for each ticker, request history individually and join.
+    per_ticker = {}
+    if isinstance(tickers, str):
+        tickers = [tickers]
+    # Use single requests per ticker to avoid ambiguous shapes
+    for t in tickers:
+        hist = yf.Ticker(t).history(start=start.isoformat(), end=end.isoformat(), interval="1d", actions=False)
+        # history() may include NaNs for some days; keep Date index and select fields
+        per_ticker[t] = hist[['High', 'Low', 'Close']]
+
+    # Combine into per-measure DataFrames
+    for measure in measures:
+        frames = []
+        for t in tickers:
+            s = per_ticker[t][measure].rename(t)
+            frames.append(s)
+        out[measure] = pd.concat(frames, axis=1).sort_index()
+
+    return out

--- a/src/Models/Allocation.py
+++ b/src/Models/Allocation.py
@@ -1,0 +1,56 @@
+# src/Models/Allocation.py
+
+from typing import List, Dict
+import pandas as pd
+from MarketDataLoader.HistoricalPricesLoader import load_prices
+from Models import PortfolioOptimizer as po
+
+
+def OptimalAllocation(
+    tickers: List[str],
+    measure: str = "Close",
+    method: str = "Markovitz",
+    allow_short: bool = False,
+    target_return: float = None
+) -> pd.Series:
+    """
+    High-level wrapper: fetch 2 years of price data, compute returns,
+    and return optimal portfolio weights.
+
+    Parameters
+    ----------
+    tickers : list[str]
+        Stock tickers (e.g. ["AAPL","MSFT","GOOG"]).
+    measure : {"Close","High","Low"}
+        Which price measure to use (default: Close).
+    method : str
+        Optimization method ("Markovitz" currently supported).
+    allow_short : bool
+        Whether short positions are allowed.
+    target_return : float, optional
+        If set, compute Markowitz portfolio with this target (annualized).
+        If None, compute min variance portfolio.
+
+    Returns
+    -------
+    pd.Series
+        Optimal weights, indexed by ticker.
+    """
+    prices = load_prices(tickers, period_days=730)
+    df = prices[measure]
+
+    # daily log returns
+    ret = po.daily_log_returns(df)
+    cov = po.annualize_cov(po.covariance_matrix(ret))
+    exp_ret = po.annualize_returns(ret)
+
+    if method.lower() == "markovitz":
+        weights = po.markowitz_weights(
+            cov,
+            exp_returns=exp_ret if target_return else None,
+            target_return=target_return,
+            allow_short=allow_short
+        )
+        return weights
+    else:
+        raise NotImplementedError(f"Method {method} not implemented")

--- a/src/Models/PortfolioOptimizer.py
+++ b/src/Models/PortfolioOptimizer.py
@@ -1,0 +1,89 @@
+"""
+portfolio_optimizer.py
+- compute log returns from price DataFrames
+- compute covariance matrices
+- compute Markowitz optimal weights (min variance or target return)
+"""
+
+from typing import Dict, Optional, List
+import numpy as np
+import pandas as pd
+from scipy.optimize import minimize
+
+
+def daily_log_returns(price_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute daily log returns for a DataFrame of prices.
+    price_df: rows = dates, columns = tickers
+    """
+    return np.log(price_df / price_df.shift(1)).dropna(how='all')
+
+
+def covariance_matrix(returns_df: pd.DataFrame) -> pd.DataFrame:
+    """Return sample covariance matrix of returns (pandas DataFrame)."""
+    return returns_df.cov()
+
+
+def min_variance_weights(cov: pd.DataFrame, allow_short: bool = False) -> pd.Series:
+    """
+    Compute minimum variance portfolio weights subject to sum(weights) = 1.
+    If allow_short is False, weights constrained to >= 0.
+    """
+    n = cov.shape[0]
+    cov_mat = cov.values
+
+    x0 = np.ones(n) / n
+    bounds = None if allow_short else tuple((0.0, 1.0) for _ in range(n))
+    cons = ({'type': 'eq', 'fun': lambda w: np.sum(w) - 1.0},)
+
+    def obj(w):
+        return w.T @ cov_mat @ w
+
+    res = minimize(obj, x0, method='SLSQP', bounds=bounds, constraints=cons)
+    if not res.success:
+        raise RuntimeError("Optimization failed: " + str(res.message))
+    return pd.Series(res.x, index=cov.index)
+
+
+def markowitz_weights(cov: pd.DataFrame,
+                      exp_returns: Optional[pd.Series] = None,
+                      target_return: Optional[float] = None,
+                      allow_short: bool = False) -> pd.Series:
+    """
+    If target_return is None -> return minimum variance portfolio.
+    If target_return specified -> solve for minimal variance with expected return == target_return.
+    exp_returns: pandas Series indexed as cov.index (annualized or same units as target_return).
+    target_return: scalar (same units as exp_returns). If exp_returns is daily, use daily target.
+    """
+    if target_return is None or exp_returns is None:
+        return min_variance_weights(cov, allow_short=allow_short)
+
+    n = cov.shape[0]
+    cov_mat = cov.values
+    mu = exp_returns.loc[cov.index].values
+
+    x0 = np.ones(n) / n
+    bounds = None if allow_short else tuple((0.0, 1.0) for _ in range(n))
+
+    cons = [
+        {'type': 'eq', 'fun': lambda w: np.sum(w) - 1.0},
+        {'type': 'eq', 'fun': lambda w: float(np.dot(w, mu) - target_return)}
+    ]
+
+    def obj(w):
+        return float(w.T @ cov_mat @ w)
+
+    res = minimize(obj, x0, method='SLSQP', bounds=bounds, constraints=cons)
+    if not res.success:
+        raise RuntimeError("Optimization failed: " + str(res.message))
+    return pd.Series(res.x, index=cov.index)
+
+
+def annualize_returns(daily_returns: pd.DataFrame, trading_days: int = 252) -> pd.Series:
+    """Convert daily mean returns to annualized arithmetic returns (approx): mean * trading_days"""
+    return daily_returns.mean() * trading_days
+
+
+def annualize_cov(cov_daily: pd.DataFrame, trading_days: int = 252) -> pd.DataFrame:
+    """Scale daily covariance matrix to annual using trading_days"""
+    return cov_daily * trading_days

--- a/tests/test_markovitz.py
+++ b/tests/test_markovitz.py
@@ -1,0 +1,29 @@
+import pytest
+from Models.Allocation import OptimalAllocation
+
+def test_optimal_allocation_us_stocks():
+    tickers = ["AAPL", "MSFT", "GOOG", "AMZN"]
+    weights = OptimalAllocation(tickers, method="Markovitz", allow_short=False)
+    assert len(weights) == len(tickers)
+    assert pytest.approx(weights.sum(), abs=1e-6) == 1.0
+    assert all(0 <= w <= 1 for w in weights)
+
+def test_optimal_allocation_french_stocks():
+    tickers = ["ENGI.PA", "TTE.PA", "SAN.PA", "ACA.PA"]
+    weights = OptimalAllocation(tickers, method="Markovitz", allow_short=False)
+    assert len(weights) == len(tickers)
+    assert pytest.approx(weights.sum(), abs=1e-6) == 1.0
+    assert all(0 <= w <= 1 for w in weights)
+
+def test_optimal_allocation_french_stocks_with_target_return():
+    tickers = ["ENGI.PA", "TTE.PA", "SAN.PA", "ACA.PA"]
+    target_return = 0.10
+    weights = OptimalAllocation(
+        tickers,
+        method="Markovitz",
+        allow_short=False,
+        target_return=target_return
+    )
+    assert len(weights) == len(tickers)
+    assert pytest.approx(weights.sum(), abs=1e-6) == 1.0
+    assert all(0 <= w <= 1 for w in weights)


### PR DESCRIPTION
This PR introduces OptimalAllocation(), a high-level method that fetches 2 years of historical stock prices (High/Low/Close) from Yahoo Finance, computes daily log returns and covariance matrices, and returns optimal portfolio weights using the Markowitz mean-variance framework.

Supports both minimum-variance portfolios and target-return portfolios, with an optional no-short constraint. This simplifies portfolio allocation for users to a single, easy-to-use function while keeping data fetching and computation fully automated.

Tests are also added :)